### PR TITLE
Do not search if query is not for 'any'

### DIFF
--- a/mopidy_radionet/library.py
+++ b/mopidy_radionet/library.py
@@ -85,6 +85,8 @@ class RadioNetLibraryProvider(backend.LibraryProvider):
             return []
 
     def search(self, query=None, uris=None, exact=False):
+        if 'any' not in query:
+            return None
 
         result = []
 


### PR DESCRIPTION
Mopidy-Radionet will crash (and make the Mopidy search system crash with it) if the query has no key "any". This happens when searching specific fields. Since searching for a radio name only makes sense with "any", my patch will make mopidy-radionet skip the search entirely if "any" isn't present.